### PR TITLE
Function that can be imported to generate pairwise annotations to dataframe

### DIFF
--- a/fr3d/data/mapping.py
+++ b/fr3d/data/mapping.py
@@ -30,7 +30,8 @@ else:
 def create_modified_nucleotide_to_parent_mappings():
     # Read in mapping file from the folder where this program is installed
     current_path,current_program = os.path.split(os.path.abspath(__file__))
-    filename = os.path.join(current_path,"atom_mappings_refined.txt")
+    # filename = os.path.join(current_path,"atom_mappings_refined.txt")
+    filename = os.path.join(current_path,"atom_mappings.txt")
 
     #print('mapping.py is being run in path %s' % current_path)
     #print('mapping.py is trying to open %s' % filename)

--- a/requirements-python-2-7.txt
+++ b/requirements-python-2-7.txt
@@ -22,3 +22,4 @@ subprocess32==3.5.4
 typing==3.7.4.1
 virtualenv==20.0.18
 zipp==1.2.0
+pandas


### PR DESCRIPTION
Hello,

Just wrote a small modification of one of the NA annotation functions to serve my purposes and thought it could be helpful to others. 

Usage:

```python
from fr3d.classifiers.NA_pairwise_interactions import generatePairwiseAnnotation_import 

print(generatePairwiseAnnotation_import("3ox0.cif", category='basepair'))
```

Output:

```
  Found 77 nucleotide-nucleotide interactions
     category           from interaction             to  crossing
0    basepair  3OX0|1|A|C|70         cHS  3OX0|1|A|U|69         0
1    basepair  3OX0|1|B|C|70         cHS  3OX0|1|B|U|69         0
2    basepair  3OX0|1|A|U|69         cSH  3OX0|1|A|C|70         0
3    basepair  3OX0|1|B|U|69         cSH  3OX0|1|B|C|70         0
4    basepair  3OX0|1|A|A|41         cSS   3OX0|1|B|C|5         0
..        ...            ...         ...            ...       ...
133  basepair  3OX0|1|B|C|39         tWH  3OX0|1|B|A|64         0
134  basepair  3OX0|1|B|G|84         tSS  3OX0|1|A|A|41         0
135  basepair  3OX0|1|B|G|73         tSS  3OX0|1|B|A|11         1
136  basepair  3OX0|1|A|G|84         tSS  3OX0|1|B|A|41         0
137  basepair  3OX0|1|A|G|73         tSS  3OX0|1|A|A|11         1

[138 rows x 5 columns]
```

The function only takes the path to an mmCif file and returns a pandas dataframe which stores the list of annotations as you can see above.

Happy to work on it some more if you want to integrate it to master.

Best,
Carlos