### PR TITLE
Fix json output in NA_pairwise_interactions.py

### DIFF
--- a/fr3d/classifiers/NA_pairwise_interactions.py
+++ b/fr3d/classifiers/NA_pairwise_interactions.py
@@ -3110,7 +3110,7 @@ def write_ebi_json_output_file(outputNAPairwiseInteractions,pdbid,interaction_to
                 inter = interaction.replace("w","W").replace("s","S").replace("h","H")
             # if this category has a restricted list of interactions to output
             if len(categories[category]) == 0 or inter in categories[category]:
-                for a,b,c in interaction_to_list_of_tuples[tn+interaction]:
+                for a,b,c in interaction_to_list_of_tuples[interaction]:
                     fields1 = a.split("|")
                     fields2 = b.split("|")
                     if fields1[2] == chain and fields2[2] == chain:


### PR DESCRIPTION
This command fails:

```
python fr3d-python.git/fr3d/classifiers/NA_pairwise_interactions.py -i rna/input/ -o rna/output/ -f ebi_json 6TNA
```

with `unknown variable: tn` on line 3113.

Simply removing the `tn` from the line seems to fix the script.