### PR TITLE
fix: Correctly add biopython dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,9 @@ license = { text = "Apache-2.0"}
 dependencies = [
 	"numpy",
 	"scipy",
-	"mmcif-pdbx; python_version>='3.0'"
-    "biopython"
+	"mmcif-pdbx; python_version>='3.0'",
+	"biopython"
 ]
 
 [tools.setuptools]
 packages = ["fr3d"]
-
-
-
-


### PR DESCRIPTION
Fixes a bug introduced in #42 

Without this fix, cloning and running `pip install -e .` fails during parsing of pyproject.toml.